### PR TITLE
bump bitcoin to 0.32.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ amplify = { version = "=4.8.1", features = [
 ] }
 baid64 = "=0.4.1"
 base85 = "=2.0.0"
-bitcoin = { version = "0.32.7", features = [
+bitcoin = { version = "0.32.8", features = [
     "serde",
 ] }
 chrono = "0.4.38"

--- a/src/dbc/opret/mod.rs
+++ b/src/dbc/opret/mod.rs
@@ -78,6 +78,6 @@ impl Proof<Method> for OpretProof {
     fn method(&self) -> Method { Method::OpretFirst }
 
     fn verify(&self, msg: &Commitment, tx: &Tx) -> Result<(), EmbedVerifyError<OpretError>> {
-        tx.verify(msg, self)
+        <Tx as EmbedCommitVerify<Commitment, OpretFirst>>::verify(tx, msg, self)
     }
 }


### PR DESCRIPTION
I noticed some RLN tests were failing due to a Bitcoin version mismatch.
This PR bumps `bitcoin` to `0.32.8` to align dependencies and fix the failures.